### PR TITLE
Wrong translation

### DIFF
--- a/src/content/lesson/what-is-an-array-define-array.es.md
+++ b/src/content/lesson/what-is-an-array-define-array.es.md
@@ -194,7 +194,7 @@ Actualizará el arreglo actual dejando todo menos la versión más pequeña que 
 <div align="right"><small><a href="https://repl.it/@4GeeksAcademy/Slice-vs-Splice">Click para abrir el demo en una ventana nueva</a></small></div>
 
 [[info]]
-| :point_up: Slice puede aceptar tantos parámentos opcionales como se quiera y estos sustituirán la parte del array que ha sido eliminada.  De esta forma el primer parámetro indica el índice desde el que empieza a borrar, el segundo parámetro cuantos elementos borrar y del tercero en adelante los elementos que se insertan a partir de la posición que se indica en el primer parámetro.
+| :point_up: Splice puede aceptar tantos parámentos opcionales como se quiera y estos sustituirán la parte del array que ha sido eliminada.  De esta forma el primer parámetro indica el índice desde el que empieza a borrar, el segundo parámetro cuantos elementos borrar y del tercero en adelante los elementos que se insertan a partir de la posición que se indica en el primer parámetro.
 
 Ejemplo:
 ```javascript


### PR DESCRIPTION
In the English version it's said 'Splice can accept as many optional paramenters as wanted and those will substitute the part of the array that has been deleted.', but in the Spanish versión it' s translated Splice by Slice.