### PR TITLE
Cambio Link de how to ask porque estaba roto

### DIFF
--- a/src/content/lesson/intro-to-prework.es.md
+++ b/src/content/lesson/intro-to-prework.es.md
@@ -49,7 +49,7 @@ Si te sientes abrumado y confundido, <span style="color:#993300">**¡¡pide ayud
 
 ### Por Favor Pide Ayuda!
 
-¿Has leído sobre Einstein?  Las personas realmente inteligentes son las que siempre hacen más preguntas. No tienen miedo a no saber o cometer errores. La única manera en que realmente podemos ayudarte es si nos pides ayuda. Para poder hacerlo, cuando estés estancado y hayas intentado resolver tu duda por tu cuenta durante algunos minutos, pregunta en nuestro canal de Slack [#Public_Support](https://4geeksacademy.slack.com/archives/CAZ9W99U4), pero antes lee estos consejos sobre [¿Cómo hacer preguntas de programación?](https://content.breatheco.de/es/how-to/ask.es). 
+¿Has leído sobre Einstein?  Las personas realmente inteligentes son las que siempre hacen más preguntas. No tienen miedo a no saber o cometer errores. La única manera en que realmente podemos ayudarte es si nos pides ayuda. Para poder hacerlo, cuando estés estancado y hayas intentado resolver tu duda por tu cuenta durante algunos minutos, pregunta en nuestro canal de Slack [#Public_Support](https://4geeksacademy.slack.com/archives/CAZ9W99U4), pero antes lee estos consejos sobre [¿Cómo hacer preguntas de programación?](https://content.breatheco.de/how-to/ask). 
 
 Si al preguntar aún no has resuelto tus dudas ¡no te preocupes! Si estás inscrito en nuestros programas de 9 o 16 semanas, tendrás acceso a mentorías ilimitadas, [mira aquí cómo funcionan](https://storage.cloud.google.com/4geeks-academy-website/syllabus/madrid-spain/madrid-infografia-mentorias.pdf)
 


### PR DESCRIPTION
EL link de how to ask directo en español está roto así que lo puse en inglés y que el estudiante lo cambie a español.