### PR TITLE
Update css-layouts.md - Change from inside to in

### DIFF
--- a/src/content/lesson/css-layouts.md
+++ b/src/content/lesson/css-layouts.md
@@ -82,7 +82,7 @@ In order for a website to look like today’s websites, we have to redesign the 
 |**Name**   |**Description**   |
 |:----------|:-----------------|
 |Static     |This does not involve any special positioning of the elements.  As a consequence, the top, left, right and bottom attributes are not considered.    |
-|Absolute    |When you tell a box that its position is absolute, you also need to define the top, bottom, left and right rules. Here, you are asking the box to ignore where it was positioned inside the HTML document.  Its new position will be based on the rules (top, left, right and bottom that you specified in the CSS).    |
+|Absolute    |When you tell a box that its position is absolute, you also need to define the top, bottom, left and right rules. Here, you are asking the box to ignore where it was positioned in the HTML document.  Its new position will be based on the rules (top, left, right and bottom that you specified in the CSS).    |
 |Relative    |Similar to absolute. The main difference here is that its position in the HTML document is not ignored.  The box will be located in accordance to the top, left, right and bottom attributes – relative to its main (boss/principal/father) element as the starting point.    |
 |Fixed     |If you fix an element, it means that it will always remain in the same position.  When the user scrolls in any direction, the element will stay in the very same position. Fixed could be used on PopUps, menu, etc.    |
 


### PR DESCRIPTION
In the section The Position Attribute, specifically in the Description of Absolute it said "... was positioned INSIDE the HTML document." when spelled it should be "... was positioned IN the HTML document."