### PR TITLE
Eliminar la / en el comando "find"

### DIFF
--- a/src/content/lesson/the-command-line-the-terminal.md
+++ b/src/content/lesson/the-command-line-the-terminal.md
@@ -159,7 +159,7 @@ cp path/to/file.ext path/to/new/file.ext
 Finds a file in the given directory and with the given specifications.
 
 ```bash
-find / -name game
+find / -name game (sin /)
 #find all files containing the exact name "game" that are inside the root folder. 
 
 find . -name *.mp3


### PR DESCRIPTION
Hola buenas, he comprobado que al introducir el comando "find / -name game... me da error, y he buscado información adicional en internet y lo correcto sería ponerlo como: "find  - name game".

un saludo y gracias.