### PR TITLE
Fix the Misspell Challenge

### DIFF
--- a/src/content/lesson/learn-in-public.es.md
+++ b/src/content/lesson/learn-in-public.es.md
@@ -45,7 +45,7 @@ Cuando aprendes en público, conviertes las redes sociales en tu cuaderno de not
 
 ### No tengo nada que decir
 
-Realmente lo dudo, aprender a codificar es difícil y la gente lee mucho sobre ello y necesita apoyo emocional, s0lo con tu testimonio estás ayudando a muchos y mucha gente estará interesada en conocer tu historia.
+Realmente lo dudo, aprender a codificar es difícil y la gente lee mucho sobre ello y necesita apoyo emocional, solo con tu testimonio estás ayudando a muchos y mucha gente estará interesada en conocer tu historia.
 
 ### No soy un experto
 

--- a/src/content/lesson/learn-in-public.es.md
+++ b/src/content/lesson/learn-in-public.es.md
@@ -45,7 +45,7 @@ Cuando aprendes en público, conviertes las redes sociales en tu cuaderno de not
 
 ### No tengo nada que decir
 
-Realmente lo dudo, aprender a codificar es difícil y la gente lee mucho sobre ello y necesita apoyo emocional, sólo con tu testimonio estás ayudando a muchos y mucha gente estará interesada en conocer tu historia.
+Realmente lo dudo, aprender a codificar es difícil y la gente lee mucho sobre ello y necesita apoyo emocional, s0lo con tu testimonio estás ayudando a muchos y mucha gente estará interesada en conocer tu historia.
 
 ### No soy un experto
 


### PR DESCRIPTION
En la parte de "Razones por las que tienes que procrastinar esto:" primer parrafo de "No tengo nada que decir" hay una palabra "sólo" que hace un tiempo la RAE conrrigió ahora se redacta sin el acento seria de este modo "solo" es el error que encontre para el Misspell Challenge