### PR TITLE
Update learn-in-public.es.md

### DIFF
--- a/src/content/lesson/learn-in-public.es.md
+++ b/src/content/lesson/learn-in-public.es.md
@@ -35,7 +35,7 @@ Cuando aprendes en público, conviertes las redes sociales en tu cuaderno de not
 - Crea cuentas en algunas de tus redes sociales preferidas como: LinkedIn (muy recomendable), Twitter, Instagram, Redit, etc.
 - Asegúrate de que tu perfil en esas cuentas se vea bien: Un perfil profesional, que te describa bien como desarrollador.
 - Cada vez que construyas un proyecto asegúrate de publicarlo en tus redes sociales, [aquí tienes un ejemplo de publicación de uno de los alumnos de la Academia 4Geeks](https://www.linkedin.com/feed/update/urn:li:activity:6750086679345815552/).
-- Únete a [#100DaysOfCode](https://www.100daysofcode.com/) y hazlo público en twitter, instagram y/o LinkedIn, ¡hay mucha gente siguiendo ese reto, puedes unirte a la discusión y colaboración!
+- Únete a [#100DaysOfCode](https://www.100daysofcode.com/) y hazlo público en Twitter, Instagram y/o LinkedIn, ¡hay mucha gente siguiendo ese reto, puedes unirte a la discusión y colaboración!
 - Crea un canal de youtube: Empieza a publicar vídeos sobre tu proceso de aprendizaje.
 - Crea un blog: Utiliza Medium (recomendado), Reddit o construye tu propia plataforma de blog y comienza a publicar posts semanales sobre lo que estás aprendiendo.
 - Acércate a los desarrolladores que admiras: Si te ha gustado un vídeo, escríbele algo al autor.  Si te gusta una librería ¡haz un Pull Request corrigiendo un error ortográfico o mejorando la documentación o codificando una nueva característica!


### PR DESCRIPTION
Tomando de referencia a FundéuRAE: "Los nombres de marcas se escriben con inicial mayúscula también cuando se usan para referirse a objetos o productos de la marca en cuestión, según señala la Ortografía de las Academias." Saludos.