### PR TITLE
Error en la Línea 14: ", and" en lugar de "and"

### DIFF
--- a/src/content/lesson/bootstrap-tutorial-of-bootstrap-5.md
+++ b/src/content/lesson/bootstrap-tutorial-of-bootstrap-5.md
@@ -11,7 +11,7 @@ status: "published"
 
 ## Bootstrap fixed all CSS major problems
 
-There is light at the end of the tunnel and it is NOT Chuck Norris holding a flashlight.  Finally, someone fixed CSS.  This is a library made by [Mark Otto](https://twitter.com/mdo?lang=en) and [Jacob Thornton](https://twitter.com/fat) – normal people – developers like you and me, and they did great!
+There is light at the end of the tunnel, and it is NOT Chuck Norris holding a flashlight.  Finally, someone fixed CSS.  This is a library made by [Mark Otto](https://twitter.com/mdo?lang=en) and [Jacob Thornton](https://twitter.com/fat) – normal people – developers like you and me, and they did great!
 
 These two guys working on Twitter were suffering the same problems we have been dealing with in HTML and CSS.  Fed up with the situation, they decided to build a **base CSS Sheet designed to be imported into any website**.  It makes every front-end development work 4x’s easier.
 


### PR DESCRIPTION
Se deben de usar coma antes de 'y', todo ello si conecta dos cláusulas independientes (a menos que estén estrechamente conectadas y sean cortas). En este caso estimo que debería corregirse dicho aspecto.