### PR TITLE
Error de Escritura

### DIFF
--- a/src/content/lesson/intro-to-4geeks.es.md
+++ b/src/content/lesson/intro-to-4geeks.es.md
@@ -72,7 +72,7 @@ Estos números no son pequeños, 60% en un día y 90% si no practicas en una sem
 
 1. **Habla con tu pareja, amigo y familia:** Necesitas un descanso de prácticamente todo. Sabemos que la vida ya es lo suficientemente complicada para además añadirle más responsabilidades, pero este es sólo un breve periodo de tu tiempo. La recompensa es eterna ¡Todos deben alinearse! Intenta mantenerte abierto, tener un escritorio para trabajar sin distracciones, etc. Tu hogar debe estar sincronizado con este momento de tu vida.
 
-2. **Habla con tu jefe:** Es posible que necesites algunas horas extra, tiempo de fin de semana, etc. Se inteligente al respecto o él/ella podría sabotearte porque tiene miedo de perderte.
+2. **Habla con tu jefe:** Es posible que necesites algunas horas extra, tiempo de fin de semana, etc. Sé inteligente al respecto o él/ella podría sabotearte porque tiene miedo de perderte.
 
 3. **No faltes a clases:** Que faltes a clases es nuestra mayor preocupación, estamos muy preocupados de la asistencia porque ha demostrado ser el disuasivo #1 para tu motivación, faltar a dos clases seguidas genera la tormenta perfecta. Necesitarás mentoría uno a uno y doblar las horas de práctica esa semana para evitar retrasarte.
 


### PR DESCRIPTION
«Sé» es voz tónica y lleva tilde diacrítica cuando es forma del verbo «ser» o «saber»: Sé bueno. No sé nada.
«Se» es pronombre átono o indicador de impersonalidad o pasiva refleja y se escribe sin tilde: Se lo dije. Se duerme bien. Se venden mesas.

Por lo tanto, en este caso lleva tilde