### PR TITLE
Update learn-react-js-tutorial.es.md

### DIFF
--- a/src/content/lesson/learn-react-js-tutorial.es.md
+++ b/src/content/lesson/learn-react-js-tutorial.es.md
@@ -234,7 +234,7 @@ Supongamos que tiene un [sitio web de una página](https://onepagelove.com/what-
 
 ```jsx 
 
-export function EntireWebsiteLayout (){
+export class EntireWebsiteLayout extends React.Component{
     
     render(){
         return (

--- a/src/content/lesson/learn-react-js-tutorial.es.md
+++ b/src/content/lesson/learn-react-js-tutorial.es.md
@@ -234,17 +234,14 @@ Supongamos que tiene un [sitio web de una página](https://onepagelove.com/what-
 
 ```jsx 
 
-export class EntireWebsiteLayout extends React.Component{
-    
-    render(){
-        return (
-            <div>
-                <Home />
-                <AboutUs />
-                <ContactUs />
-            </div>
-        );
-    }
+export function EntireWebsiteLayout (){
+    return (
+        <div>
+            <Home />
+            <AboutUs />
+            <ContactUs />
+        </div>
+    );
 }
 //Está implícito que los componentes Home, AboutUs y ContactUs ya han sido definidos
 ```


### PR DESCRIPTION
Creo que falta definir la **class** en el ejemplo que he modificado.

Para evitar usar el componente de clase quizás sería interesante dejarlo como componente funcional, pero me he dado cuenta que un poco más abajo se usa una imagen relacionada con este componente de clase.