### PR TITLE
Cambio de nombre de función en el ejemplo 1 de algoritmo asíncrono

### DIFF
--- a/src/content/lesson/asynchronous-algorithms-async-await.es.md
+++ b/src/content/lesson/asynchronous-algorithms-async-await.es.md
@@ -34,7 +34,7 @@ RESULTADO EN CONSOLA:
 */
 ```
 
-Aquí: la línea 5 se ejecuta antes de la línea 2 porque estamos llamando a ```correSegundo ()``` (línea 7) antes de ```correPrimero ()``` (línea 8). Rompiendo el orden de mando de la computadora que *llama* (o ejecuta) el bloque de código dentro de una función.
+Aquí: la línea 5 se ejecuta antes de la línea 2 porque estamos llamando a ```ejecutarSegundo ()``` (línea 7) antes de ```ejecutarPrimero ()``` (línea 8). Rompiendo el orden de mando de la computadora que *llama* (o ejecuta) el bloque de código dentro de una función.
 
 Las cosas se complican más cuando se llaman funciones dentro de funciones, como podemos ver aquí:
 


### PR DESCRIPTION
En el ejemplo 1 (asíncrono por defecto)

Las funciones se llaman ejecutarSegundo() y ejecutarPrimero(). Pero cuando se explica el código en el texto de abajo, la llaman correSegundo() y correPrimero()