### PR TITLE
Update learn-in-public.es.md

### DIFF
--- a/src/content/lesson/learn-in-public.es.md
+++ b/src/content/lesson/learn-in-public.es.md
@@ -41,7 +41,7 @@ Cuando aprendes en público, conviertes las redes sociales en tu cuaderno de not
 - Acércate a los desarrolladores que admiras: Si te ha gustado un vídeo, escríbele algo al autor.  Si te gusta una librería, ¡haz un Pull Request corrigiendo un error ortográfico o mejorando la documentación o codificando una nueva característica!
 - Participa en eventos y conferencias: Reúnete con otros desarrolladores y las oportunidades empezarán a llegar.
 
-## Razones por las que tienes que procrastinar esto:
+## Razones por las que no tienes que procrastinar esto:
 
 ### No tengo nada que decir
 


### PR DESCRIPTION
En este artículo se anima a los lectores ( en su mayor caso alumnos) a no procrastinar en las tareas y maneras de aprender, vincular, organizar y compartir conocimiento. 

En su punto 5, se especifica lo siguiente: 

## Razones por las que tienes que procrastinar esto:

Siendo su versión correcta:

## Razones por las que no tienes que procrastinar esto:

Ya que su objetivo es animar al lector a no procrastinar en empezar a hacer todo lo que el articulo anima a hacer y no a posponerlo. 

Por lo tanto, creo que es conveniente poner la negación para cambiar su significado! 