### PR TITLE
Fix Ortográfico

### DIFF
--- a/src/content/lesson/what-is-react-flux.es.md
+++ b/src/content/lesson/what-is-react-flux.es.md
@@ -32,7 +32,7 @@ Aquí hay una lista de todas las ventajas de usarlo:
 |&nbsp;     |&nbsp;       |
 |:-----------|:----------------|
 Vistas/Views (Components)     |Cada componente React que llama a cualquier acción Flux es llamada una vista.  La razón para llamar a esos componentes de una manera diferente es porque se supone que los componentes de React se comunican entre sí a través de sus accesorios (sin Flux).<br> <br>Una vez que un componente React esté vinculado de forma rígida a Flux, no podrá reutilizar ese componente en el futuro (en este o en cualquier otro desarrollo).       |
-|Acciones (Actions)       |Las acciones pueden ser activadas por componentes (cuando el usuario hace clic o interactúa con la aplicación) o por el sistema (por ejemplo, la funcionalidad de guardado automático).  Las acciones son el primer paso de cualquier flujo de trabajo de Flux y siempre deben enviarse a la tienda.      |
+|Acciones (Actions)       |Las acciones pueden ser activadas por componentes (cuando el usuario hace clic o interactúa con la aplicación) o por el sistema (por ejemplo, la funcionalidad de guardado automático).  Las acciones son el primer paso de cualquier flujo de trabajo de Flux y siempre deben enviarse al Store.      |
 | Store     |El store contiene todos los datos de la aplicación. Maneja todo lo que recibe el despachador y determina la forma en que se deben almacenar y recuperar los datos.            |
 
 ## Construyendo nuestra primera historia de usuario con Flux


### PR DESCRIPTION
"siempre deben enviarse a la tienda" no tiene sentido traducir Store en ese contexto, ya que mas nunca se le vuelve a mencionar como "tienda"