### PR TITLE
Replaced "the Card" with a Card

### DIFF
--- a/src/content/lesson/bootstrap-tutorial-of-bootstrap-4.md
+++ b/src/content/lesson/bootstrap-tutorial-of-bootstrap-4.md
@@ -194,7 +194,7 @@ This is probably the most used Bootstrap component; every website has a few card
 + The typical Pinterest wall.
 + The feed in any social media like Instagram, Facebook, twitter, etc.
 
-Here is an example of how a "The Card" may look on a website:
+Here is an example of how a Card may look on a website:
 
 ![bootstrap 4](https://github.com/breatheco-de/content/blob/master/src/assets/images/39d36b52-330f-4ce9-beab-2004e325749c.png?raw=true)
 


### PR DESCRIPTION
> "The Card" was not grammatically correct in the lesson "Learn bootstrap 4 in 10 minutes" inside the section about cards. Preceding the code, a title said "Here is an example of how "the Card" may look on the website." The quotation marks where unnecessary and "the" should be "a". I believe the capital should stay as that highlights what the paragraph is referring to.