### PR TITLE
UPDATE LINK TO PUBLIC-APIS :  understanding-rest-apis.md

### DIFF
--- a/src/content/lesson/understanding-rest-apis.md
+++ b/src/content/lesson/understanding-rest-apis.md
@@ -99,4 +99,5 @@ Several documents and guides are provided below to reinforce knowledge about RES
 - [ReadTheDocs](https://restful-api-design.readthedocs.io/en/latest/resources.html)
 - [RESTfulAPI.net](https://restfulapi.net/)
 
-> 🔗 This is a list of public APIs that can be used for personal, professional and educational projects: https://github.com/public-apis/public-apis
+> 🔗 This is a list of public APIs that can be used for personal, professional and educational projects:
+https://github.com/marcelscruz/public-apis


### PR DESCRIPTION
* Please see this issue : https://github.com/public-apis/public-apis/issues/3104

* Because of this, I'm proposing that we change the link of our lesson page to this: https://github.com/marcelscruz/public-apis vs. the original: https://github.com/public-apis/public-apis (where public concerns are not heard and it's not maintained to the public interest). There is also this fork, however I don't believe this is maintined as well (https://github.com/public-api-lists/public-api-lists). 

* As a community of developers and new students, we should use this new link for public apis and help the community make this the new standard github link for public apis. Why should we use the one that's not maintained and geared toward public anymore?