### PR TITLE
Replaced incorrect image in "What is HTTP"

### DIFF
--- a/src/content/lesson/what-is-http.md
+++ b/src/content/lesson/what-is-http.md
@@ -28,7 +28,7 @@ This communication, as shown in the following gif, is carried out through a proc
 
 ### How does HTTP work?
 
-![HTTP diagram](https://github.com/breatheco-de/content/blob/master/src/assets/images/http-3.png?raw=true)
+![HTTP stages](https://breathecode.herokuapp.com/v1/media/file/http-steps-png?raw=true)
 
 The HTTP protocol works through requests and responses from the client (e.g., a web browser) and a server (e.g., the computers that host and display websites). 
 


### PR DESCRIPTION
Somehow an image with Spanish writing had made its way back into the English version of the lesson. Bringing back the English-captioned image.