### PR TITLE
fix spelling error in the destination route

### DIFF
--- a/src/content/lesson/the-command-line-the-terminal.es.md
+++ b/src/content/lesson/the-command-line-the-terminal.es.md
@@ -90,7 +90,7 @@ cd /path/to/directory
 Mueve un archivo a otra carpeta o directorio, como por ejemplo arrastrar un archivo ubicado en el escritorio de una PC a una carpeta almacenada dentro de la carpeta "Documentos".
 
 ```bash
-mv /path/to/file.txt /math/to/destination/file.txt
+mv /path/to/file.txt /path/to/destination/file.txt
 ```
 
 ### El comando rm


### PR DESCRIPTION
Small fix in the destination route in the explanation of the mv command "line 93". 

error:           mv /path/to/file.txt  /math/to/destination/file.txt

correct:        mv /path/to/file.txt  /path/to/destination/file.txt