### PR TITLE
Update bootstrap-tutorial-of-bootstrap-4.es.md

### DIFF
--- a/src/content/lesson/bootstrap-tutorial-of-bootstrap-4.es.md
+++ b/src/content/lesson/bootstrap-tutorial-of-bootstrap-4.es.md
@@ -250,7 +250,7 @@ div class="modal" tabindex="-1" role="dialog">
 
 ## Lo que realmente necesitas saber sobre Bootstrap
 
-¡¡La documentación oficial de Bootstrap es increíble!! No necesitamos copiar y pegar todos los post. Por favor visita los siguientes sitios web y enfócate en leer estos temas:
+¡¡La documentación oficial de Bootstrap es increíble!! No necesitamos copiar y pegar todos los posts. Por favor visita los siguientes sitios web y enfócate en leer estos temas:
 
 + [The grid system.](https://getbootstrap.com/docs/4.1/layout/grid/)
 + [Styling Forms.](https://getbootstrap.com/docs/4.1/components/forms/)


### PR DESCRIPTION
Modifique la oración "¡¡La documentación oficial de Bootstrap es increíble!! No necesitamos copiar y pegar todos los post." Correcciones: "post" → "posts": En español, el plural de "post" es "posts".