### PR TITLE
correción de sintaxis en aptdo. 'excusas para no aprender en público…

### DIFF
--- a/src/content/lesson/learn-in-public.es.md
+++ b/src/content/lesson/learn-in-public.es.md
@@ -40,7 +40,7 @@ Cuando aprendes en público, conviertes las redes sociales en tu cuaderno de not
 ## Excusas para no aprender en público:
 
 ### No tengo nada que decir:
-Realmente lo dudo. Aprender a programar es difícil y la gente lee mucho sobre ello y necesita apoyo emocional. Solo con tu testimonio estás ayudando a muchos y mucha gente estará interesada en conocer tu historia.
+Realmente lo dudo. Aprender a programar es difícil y la gente lee mucho sobre ello y necesita apoyo emocional. Solo con tu testimonio estás ayudando a muchas personas, y mucha gente estará interesada en conocer tu historia.
 
 ### No soy un experto: 
 Nadie lo es. Llevo 20 años programando y sigo pensando que no soy un experto. Al mostrar tu perspectiva sobre los temas que acabas de aprender, estás ayudando a otros aficionados en su camino.


### PR DESCRIPTION
Correción de sintaxis/ortografía.

LECCIÓN: Aprende en público.
Apartado: Excusas para no aprender en público.
Párrafo: No tengo nada que decir.

Texto corregido:
Realmente lo dudo. Aprender a programar es difícil y la gente lee mucho sobre ello y necesita apoyo emocional. Solo con tu testimonio estás ayudando a ### _**muchos y mucha gente**_ estará interesada en conocer tu historia.

Correción:
Realmente lo dudo. Aprender a programar es difícil y la gente lee mucho sobre ello y necesita apoyo emocional. Solo con tu testimonio estás ### _**a muchas personas, y mucha gente**_  estará interesada en conocer tu historia.