### PR TITLE
Santiago-Rudas_Update learn-in-public.es.md_corrección ortográfica

### DIFF
--- a/src/content/lesson/learn-in-public.es.md
+++ b/src/content/lesson/learn-in-public.es.md
@@ -8,7 +8,7 @@ description: >-
   Aprende a programar eficazmente compartiendo tu proceso en público. ¡Descubre
   cómo potenciar tu carrera y construir tu red hoy!
 ---
-Si deseas aprender a programar de manera eficiente y rápida, es fundamental que lo hagas en público. Esto no es sólo una teoría, sino un hecho comprobado.  
+Si deseas aprender a programar de manera eficiente y rápida, es fundamental que lo hagas en público. Esto no es solo una teoría, sino un hecho comprobado.  
 
 En este artículo voy a intentar explicarte por qué funciona y cómo puedes hacerlo.
 


### PR DESCRIPTION
Si deseas aprender a programar de manera eficiente y rápida, es fundamental que lo hagas en público. Esto no es sólo una teoría, sino un hecho comprobado

Se quitó la tilde a la palabra solo.
La tilde es innecesaria según la norma actual. Con el sentido de «solamente» (adv.), cuando hay riesgo de ambigüedad con el adj. «solo», puede escribirse «sólo» (DRAE).