### PR TITLE
Update html-input-html-textarea.es.md

### DIFF
--- a/src/content/lesson/html-input-html-textarea.es.md
+++ b/src/content/lesson/html-input-html-textarea.es.md
@@ -78,8 +78,8 @@ Los dos atributos más importantes que deben establecerse en la etiqueta `<form>
 
 **Method**: Puede ser "POST" o "GET". Las principales diferencias son:
 
-+ Cómo se enviarán los datos recopilados a la página de destino una vez que lleguemos allí.
-+ Cómo se envían los datos del formulario al servidor.
++ Como se enviarán los datos recopilados a la página de destino una vez que lleguemos allí.
++ Como se envían los datos del formulario al servidor.
 
 |GET   |POST  |
 |:----------------------|:-----------------------|


### PR DESCRIPTION
La palabra "como" solo lleva tilde (es decir, se escribe "cómo") cuando se utiliza en oraciones interrogativas o exclamativas, ya sea directas o indirectas.