### PR TITLE
corrección de estilo y traducción  en how-to-use-git-version-control-…

### DIFF
--- a/src/content/lesson/how-to-use-git-version-control-system.es.md
+++ b/src/content/lesson/how-to-use-git-version-control-system.es.md
@@ -187,7 +187,7 @@ Después de hacer checkout en el *\[new-head\]*, fijarás los head. Ahora puedes
 
 ## Fusionando
 
-Una vez que hayas terminado de implementar una nueva fusión en una rama, querrás traer esa nueva fusión a la rama principal, para que todos puedan usarla. Puedes hacerlo con el comando `git merge` o `git pull`.
+Una vez que hayas terminado de implementar una nueva funcionalidad en una rama, querrás traerla a la rama principal, para que todos puedan usarla. Puedes hacerlo con el comando `git merge` o `git pull`.
 
 La sintaxis del comando es la siguiente:
 


### PR DESCRIPTION
…system.es.md

En la línea 190 se traduce la palabra "feature" como "fusión", lo que es redundante (el subtítulo del párrafo es Fusionando) e impreciso.

En este commit se soluciona el problema traduciendo la palabra a "funcionalidad".

además se soluciona también la redundancia de la frase:
 ... una nueva funcionalidad en una rama querrás traer esa funcionalidad a la rama... 
cambiándola por:
... una nueva funcionalidad en una rama, querrás traerla a la rama...