### PR TITLE
Update Jest expect url

### DIFF
--- a/src/content/lesson/how-to-create-unit-testing-with-Javascript-and-Jest.es.md
+++ b/src/content/lesson/how-to-create-unit-testing-with-Javascript-and-Jest.es.md
@@ -163,4 +163,4 @@ Hemos estado usando `expect(something).toBe(something)`, pero Jest tiene muchas 
 | Espera que se defina una variable | expect(variable_name).toBeDefined() |
 | Espera que un array contenga otro | expect(['a', 'b', 'c', 'e']).toEqual(expect.arrayContaining(['b', 'c'])) |
 
-> 👉 Nota: [Aquí puedes encontrar todas las posibles funciones `expect` que puedes utilizar.](https://jestjs.io/es-ES/docs/expect)
+> 👉 Nota: [Aquí puedes encontrar todas las posibles funciones `expect` que puedes utilizar.](https://jestjs.io/docs/expect)


### PR DESCRIPTION
Old url "https://jestjs.io/es-ES/docs/expect" return "Page Not Found".