### PR TITLE
Update debugging-html-code.es.md

### DIFF
--- a/src/content/lesson/debugging-html-code.es.md
+++ b/src/content/lesson/debugging-html-code.es.md
@@ -54,7 +54,7 @@ Errores de caché: Debes asegurarte de que el código que escribiste sea el mism
 
 ### 2) Inspector de herramientas de desarrollo
 
-Todos los principales navegadores tienen herramientas de desarrollo, la primera pestaña en las herramientas de desarrollo se llama "Elementos" y contiene -casi- todo lo que necesitas para solucionar tus errores.
+Todos los principales navegadores tienen herramientas de desarrollo, la primera pestaña en las herramientas de desarrollo se llama "Elementos" y contiene casi todo lo que necesitas para solucionar tus errores.
 
 ![Inspector de código HTML](https://i.imgur.com/Fca0Hkm.gif?raw=true)
 


### PR DESCRIPTION
Se hizo una modificación en la línea 57. Se quitaron dos guiones medios que estaban en un inicio y en un final de la palabra "casi".

Texto antes de modificación: 
-casi- 

Texto después de modificación:
casi