### PR TITLE
Applied Feyman teaching method for better comprehension

### DIFF
--- a/src/content/lesson/learn-in-public.md
+++ b/src/content/lesson/learn-in-public.md
@@ -9,31 +9,48 @@ description: >-
   Embrace sharing your journey and connect with others today!
 ---
 
-If you're learning at 4Geeks, whether it's Full Stack, Cybersecurity, Vibe Coding, AI, or any other program, you should consider learning in public. This is not just a theory, it's a proven strategy for faster learning and career growth.
+Imagine learning to cook by reading recipes in secret, never telling anyone about your burnt toast or celebrating when you finally nail the perfect pasta. You'd miss out on grandma's secret tips, your friend's shortcut for chopping onions, and that neighbor who could have warned you about oversalting the soup.
 
-In this article, we'll explain why it works and how to get started.
+Learning tech skills works the same way. If you're studying at 4Geeks—whether it's Full Stack, Cybersecurity, AI, or any other program—think of "learning in public" as cooking with the kitchen door wide open. People can see your successes, your mistakes, and everything in between.
 
-## What is Learn In Public?
+This isn't just a nice idea; it's like having a turbo engine for your learning. Let me show you why this works and how to start today.
 
-**Learning in private** is what most of us are used to: reading, attending class, completing assignments, and quietly leveling up until graduation.
+## What is Learning In Public?
 
-**Learning in public** means sharing your progress openly. That could be:
+Think of learning like building a house. Most people build their house behind a tall fence, never showing the work in progress. Only when it's "perfect" do they remove the fence and show the world their finished home.
 
-- Posting on social media
-- Writing short updates or articles
-- Sharing code or projects on GitHub
-- Creating videos, drawings, or even memes about what you’re learning
-- Commenting and engaging in forums and communities
+**Learning in private** is building behind that fence: reading, attending classes, doing assignments, quietly getting better until you "graduate" and finally show your completed skills.
 
-## Why is this so important?
+**Learning in public** is like building your house with a glass fence. Everyone can see:
+- You laying the foundation (sharing basic concepts you just learned)
+- You figuring out the plumbing (posting about debugging your first code)
+- You painting the walls (celebrating small wins on social media)
+- You asking neighbors for help (engaging in forums and communities)
 
-- Writing and teaching reinforce your learning.
-- You develop stronger communication and reasoning skills.
-- Friends, family, and peers start seeing you as “the go-to person” in tech.
-- You’ll build confidence and battle impostor syndrome by finding others on the same journey.
-- Platforms like LinkedIn will boost your visibility when you publish often.
-- Recruiters and employers will notice you—at 4Geeks, we've seen students land jobs just from posting about their progress.
-- You’ll avoid feeling isolated. On Twitter/X, thousands of people are learning and sharing every day—especially under hashtags like `#100DaysOfCode`, `#BuildInPublic`, and `#LearnToCode`. These are active, welcoming communities where you’ll find support, ideas, and encouragement.
+This could look like:
+- Writing a simple post: "Today I learned that arrays in JavaScript are like boxes with numbered slots"
+- Sharing your GitHub projects (even the messy ones!)
+- Creating a 30-second video explaining a concept to your future self
+- Drawing diagrams or making memes about what confused you
+- Asking questions and helping others in coding communities
+
+## Why This Works Like Magic
+
+Richard Feynman, the brilliant physicist, had a technique: if you can't explain something simply, you don't understand it well enough. Learning in public forces you to become your own teacher—and that's where the magic happens.
+
+Here's what happens when you learn with the glass fence:
+
+**Your brain gets stronger**: Writing and teaching are like doing mental push-ups. Every time you explain a concept, you're flexing your understanding muscles.
+
+**You become the tech person**: Imagine your brain as a search engine. When friends and family need tech help, they'll start searching for you first. That recognition builds real confidence.
+
+**You slay the impostor monster**: Impostor syndrome is like a shadow that grows in darkness. When you share your learning journey, you shine a light on it and discover thousands of others fighting the same shadows.
+
+**The algorithm becomes your friend**: LinkedIn is like a party host who introduces people. When you post consistently, the host notices and starts introducing you to recruiters and employers who are looking for someone exactly like you.
+
+**Jobs find you**: At 4Geeks, we've seen something amazing—students landing jobs not because they applied, but because employers discovered them through their public learning posts. It's like fishing where the fish jump into your boat.
+
+**You join the campfire**: Twitter/X, LinkedIn, and other platforms are like giant campfires where thousands of learners gather every day. Hashtags like `#100DaysOfCode`, `#BuildInPublic`, and `#LearnToCode` are the different circles around the fire. Everyone's sharing stories, offering help, and cheering each other on.
 
 ## How to start learning in public
 
@@ -54,24 +71,40 @@ In this article, we'll explain why it works and how to get started.
 - Contribute to open source: even a small documentation fix is a great way to learn and be seen.
 - Attend meetups and online events. Talk to other learners and professionals—you’ll be amazed at the doors that open.
 
-## Common thoughts that hold people back
+## The Voice In Your Head (And Why It's Wrong)
 
-### “I don’t have anything to say.”
+Every learner has a little voice in their head—like a worried parent who means well but holds you back. Let's have a chat with these common worries:
 
-You do. Learning to code (or break into tech in any area) is hard. Your story helps others who feel stuck or alone. Just by showing up and sharing what you're doing, you're adding value.
+### "I don't have anything interesting to say."
 
-### “I’m not an expert.”
+Imagine you're climbing a mountain, and someone behind you is struggling with the same steep section you just conquered. Would you not turn around and say, "Hey, there's a great handhold just to your left"? Your learning journey is that mountain, and your insights are those handholds for others.
 
-Nobody starts as an expert. Even senior developers constantly learn new things. Sharing your beginner perspective is actually incredibly helpful to other beginners.
+Every time you figure out why your code didn't work, or finally understand how databases talk to websites, you've discovered something valuable. Share it—because while it's fresh in your mind, it's exactly what someone else needs to hear.
 
-### “I don’t have time.”
+### "I'm not an expert—who am I to teach?"
 
-You're already taking notes, completing projects, and reflecting on what you learn. Turn some of that into public posts—just one update a week can make a big difference.
+Here's the beautiful secret: beginners are often the best teachers for other beginners. Think about learning to ride a bike. An Olympic cyclist might say, "Just balance and pedal," while another beginner will say, "I kept looking down at the ground, but when I looked ahead, everything clicked!"
+
+Your beginner's mind is a superpower. You remember what confused you yesterday, which makes you perfect for helping someone confused today.
+
+### "I don't have time for this."
+
+You're already learning—taking notes, building projects, having "aha" moments. Learning in public isn't adding new work; it's like putting a window in your workshop so people can see the amazing things you're already creating.
+
+One tweet about a bug you fixed, one LinkedIn post about a concept you mastered—these take five minutes but can change someone's day (and eventually, your career).
 
 ---
 
-We hope this inspired you to start (or continue) learning in public. If you want to go deeper, check out [this article by Shawn Wang](https://www.swyx.io/learn-in-public/) and all the amazing links at the bottom of it.
+## Your Learning Journey Awaits
 
-## Keep it up!
+Think of this moment as standing at the edge of a bright, welcoming town square. You could stay in the shadows, learning alone, or step into the light where other learners, mentors, and opportunities are waiting.
 
-Every post, tweet, or message you share brings you one step closer to confidence, community, and your next opportunity. Let the world follow your journey 🚀
+Learning in public isn't about being perfect—it's about being human. It's about saying, "I'm growing, and I'm not afraid to show the world how."
+
+For a deeper dive into this concept, explore [Shawn Wang's foundational article](https://www.swyx.io/learn-in-public/) and the treasure trove of resources at the bottom.
+
+## Start Today, Start Small
+
+Every expert was once a beginner who decided to share their journey. Every post you write, every question you ask, every small insight you share is like dropping a pebble in a pond—the ripples travel far beyond what you can see.
+
+The world is waiting to learn from you. What will you teach them today? 🌟


### PR DESCRIPTION
Completely rewrote the "Learn in Public" article applying Richard Feynman's teaching philosophy and rich metaphors to make complex concepts more accessible and engaging.

Key improvements:
• Transformed technical jargon into simple, relatable analogies (learning = house building with glass fence vs. solid fence)
• Added powerful metaphors throughout: brain as search engine, impostor syndrome as shadow, platforms as campfires
• Applied Feynman's principle: "If you can't explain it simply, you don't understand it well enough"
• Restructured content with engaging headers and conversational tone
• Addressed common learning fears with empathy and practical solutions
• Made the content more inspiring and actionable for students

The article now reads like a friendly mentor explaining why sharing your learning journey is powerful, using analogies anyone can understand - from mountain climbing to community gardens to dropping pebbles in a pond.

This approach makes the content more memorable and reduces barriers for students who might feel intimidated about learning in public.