### PR TITLE
error tecnico o de traduccion linea 164

### DIFF
--- a/src/content/lesson/the-command-line-the-terminal.es.md
+++ b/src/content/lesson/the-command-line-the-terminal.es.md
@@ -161,7 +161,7 @@ find / -name game
 # Encuentra todos los archivos que contengan el nombre exacto "game" que se encuentran dentro de la carpeta raíz.
 
 find . -name *.mp3
-# Encuentra todos los archivos que contengan la extensión "mp3" dentro del directorio actual y en el de su padre.
+# Encuentra todos los archivos que contengan la extensión "mp3" dentro del directorio actual y en sus subdirectorios" (o "carpetas hijas").
 ```
 
 ## Consejos y trucos


### PR DESCRIPTION
 el comando find . -name *.mp3, 
 En la terminal, el punto (.) significa "el directorio actual" y busca de ahí hacia abajo. No busca hacia el directorio "padre" (para el padre se usarían dos puntos ..). Seguramente el traductor original confundió subdirectories/children con parent.